### PR TITLE
perf: 换了一个方式实现的Toast通知

### DIFF
--- a/DailyRoutines/DailyRoutines.csproj
+++ b/DailyRoutines/DailyRoutines.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>net8.0-windows</TargetFramework>
+        <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
         <Platforms>AnyCPU</Platforms>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
@@ -57,6 +57,7 @@
     <ItemGroup>
         <PackageReference Include="DalamudPackager" Version="2.1.12" />
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
         <PackageReference Include="System.Management" Version="8.0.0" />
         <PackageReference Include="TinyPinyin" Version="1.1.0" />
     </ItemGroup>

--- a/DailyRoutines/Notifications/WinToast.cs
+++ b/DailyRoutines/Notifications/WinToast.cs
@@ -5,22 +5,14 @@ using System.Windows.Forms;
 using DailyRoutines.Helpers;
 using DailyRoutines.Managers;
 using ECommons.Automation;
+using Microsoft.Toolkit.Uwp.Notifications;
 
 namespace DailyRoutines.Notifications;
 
 public class WinToast : DailyNotificationBase
 {
-    private class ToastMessage(string? title, string message, ToolTipIcon icon = ToolTipIcon.Info)
-    {
-        public string? Title { get; set; } = title;
-        public string Message { get; set; } = message;
-        public ToolTipIcon Icon { get; set; } = icon;
-    }
 
     private static TaskManager? TaskManager;
-
-    private static NotifyIcon? icon;
-    private static readonly Queue<ToastMessage> messagesQueue = new();
 
     public override void Init()
     {
@@ -29,67 +21,14 @@ public class WinToast : DailyNotificationBase
 
     public static void Notify(string title, string content, ToolTipIcon toolTipIcon = ToolTipIcon.Info)
     {
-        if (icon == null || icon.Visible == false) CreateIcon();
-        messagesQueue.Enqueue(new ToastMessage(title, content, toolTipIcon));
-
-        TaskManager.DelayNext(200);
-        TaskManager.Enqueue(TryDequeueMessages);
-    }
-
-    private static void TryDequeueMessages()
-    {
-        switch (messagesQueue.Count)
-        {
-            case 0:
-                DestroyIcon();
-                break;
-            case 1:
-                ShowBalloonTip(messagesQueue.Dequeue());
-
-                TaskManager.DelayNext(6000);
-                TaskManager.Enqueue(TryDequeueMessages);
-                break;
-            case >= 2:
-                ShowBalloonTip(new ToastMessage("", Service.Lang.GetText("NotificationManager-ReceiveMultipleMessages", messagesQueue.Count)));
-                messagesQueue.Clear();
-
-                TaskManager.DelayNext(6000);
-                TaskManager.Enqueue(TryDequeueMessages);
-                break;
-        }
-    }
-
-    private static void ShowBalloonTip(ToastMessage message)
-    {
-        icon.ShowBalloonTip(
-            5000, string.IsNullOrEmpty(message.Title) ? Plugin.Name : SanitizeHelper.Sanitize(message.Title),
-            SanitizeHelper.Sanitize(message.Message), message.Icon);
-    }
-
-    private static void CreateIcon()
-    {
-        DestroyIcon();
-        icon = new NotifyIcon
-        {
-            Icon = new Icon(Path.Join(Service.PluginInterface.AssemblyLocation.DirectoryName, "Assets", "FFXIVICON.ico")),
-            Text = Plugin.Name,
-            Visible = true
-        };
-    }
-
-    private static void DestroyIcon()
-    {
-        if (icon != null)
-        {
-            icon.Visible = false;
-            icon.Dispose();
-            icon = null;
-        }
+        new ToastContentBuilder()
+            .AddText(title)
+            .AddText(content)
+            .Show();
     }
 
     public override void Uninit()
     {
-        DestroyIcon();
         TaskManager?.Abort();
     }
 }

--- a/DailyRoutines/packages.lock.json
+++ b/DailyRoutines/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net8.0-windows7.0": {
+    "net8.0-windows10.0.17763": {
       "DalamudPackager": {
         "type": "Direct",
         "requested": "[2.1.12, )",
@@ -19,6 +19,18 @@
           "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
           "Microsoft.Extensions.Options": "8.0.0",
           "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Toolkit.Uwp.Notifications": {
+        "type": "Direct",
+        "requested": "[7.1.3, )",
+        "resolved": "7.1.3",
+        "contentHash": "A1dglAzb24gjehmb7DwGd07mfyZ1gacAK7ObE0KwDlRc3mayH2QW7cSOy3TkkyELjLg19OQBuhPOj4SpXET9lg==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "4.7.0",
+          "System.Drawing.Common": "4.7.0",
+          "System.Reflection.Emit": "4.7.0",
+          "System.ValueTuple": "4.5.0"
         }
       },
       "System.Management": {
@@ -76,6 +88,28 @@
         "resolved": "8.0.0",
         "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g=="
       },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "z7aeg8oHln2CuNulfhiLYxCVMPEwBl3rzicjvIX+4sUuCwvXw5oXQEtbiU2c0z4qYL5L3Kmx0mMA/+t/SbY67w=="
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "KSrRMb5vNi0CWSGG1++id2ZOs/1QhRqROt+qgbEAdQuGjGrFcl4AOl4/exGPUYz2wUnU42nvJqon1T3U0kPXLA==",
+        "dependencies": {
+          "System.Security.AccessControl": "4.7.0",
+          "System.Security.Principal.Windows": "4.7.0"
+        }
+      },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "mtVirZr++rq+XCDITMUdnETD59XoeMxSpLRIII7JRI6Yj0LEDiO1pPn0ktlnIj12Ix8bfvQqQDMMIF9wC98oCA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0"
+        }
+      },
       "Reloaded.Memory": {
         "type": "Transitive",
         "resolved": "7.1.0",
@@ -85,6 +119,39 @@
         "type": "Transitive",
         "resolved": "8.0.0",
         "contentHash": "WTlRjL6KWIMr/pAaq3rYqh0TJlzpouaQ/W1eelssHgtlwHAH25jXTkUphTYx9HaIIf7XA6qs/0+YhtLEQRkJ+Q=="
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "v+XbyYHaZjDfn0ENmJEV1VYLgGgCTx1gnfOBcppowbpOAriglYgGCvFCPr2EEZyBvXlpxbEsTwkOlInl107ahA==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "Microsoft.Win32.SystemEvents": "4.7.0"
+        }
+      },
+      "System.Reflection.Emit": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "VR4kk8XLKebQ4MZuKuIni/7oh+QGFmZW3qORd1GvBq/8026OpW501SzT/oypwiQl4TvT8ErnReh/NzY9u+C6wQ=="
+      },
+      "System.Security.AccessControl": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "JECvTt5aFF3WT3gHpfofL2MNNP6v84sxtXxpqhLBCcDRzqsPBmHhQ6shv4DwwN2tRlzsUxtb3G9M3763rbXKDg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "System.Security.Principal.Windows": "4.7.0"
+        }
+      },
+      "System.Security.Principal.Windows": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "ojD0PX0XhneCsUbAZVKdb7h/70vyYMDYs85lwEI+LngEONe/17A0cFaRFqZU+sOEidcVswYWikYOQ9PPfjlbtQ=="
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
       },
       "clicklib": {
         "type": "Project",


### PR DESCRIPTION
- fix #96

https://learn.microsoft.com/zh-cn/windows/apps/design/shell/tiles-and-notifications/send-local-toast

存在一个问题，卸载Daily Routine然后重新装载后，通知就不可用了
```
System.InvalidOperationException: Attempt to update previously set global instance.
   at System.Runtime.InteropServices.ComWrappers.RegisterForTrackerSupport(ComWrappers instance)
   at WinRT.ComWrappersSupport.get_ComWrappers()
   at WinRT.ComWrappersSupport.TryRegisterObjectForInterface(Object obj, IntPtr thisPtr)
   at Windows.Data.Xml.Dom.XmlDocument..ctor()
   at Microsoft.Toolkit.Uwp.Notifications.ToastContent.GetXml()
   at Microsoft.Toolkit.Uwp.Notifications.ToastContentBuilder.Show(CustomizeToast customize)
   at DailyRoutines.Notifications.WinToast.Notify(String title, String content, ToolTipIcon toolTipIcon) in D:\My_Program\FFXIV_Dalamud\DailyRoutines\DailyRoutines\Notifications\WinToast.cs:line 32
```